### PR TITLE
Velocity commands in execution time

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ Step 3. Follow the instruction in the interface program, run the programs from t
 Update date: Apr. 20
 *************************************************************************
 
+# Commands
+
+* Up Arrow: Move forward
+* Down Arrow: Move backward
+* Left Arrow: Turn counter-clockwise
+* Right Arrow: Turn clockwise
+* Spacebar: Stop moving
+* A: Increase linear velocity
+* Z: Decrease linear velocity
+* S: Increase angular velocity
+* X: Decrease angular velocity
+* Q: Quit teleop 
+
 # Update Log
 
 Beta V1.0 Most of the time it works fine, sometimes it does not stop(continue going ahead or continue spinning).

--- a/src/teleop.cpp
+++ b/src/teleop.cpp
@@ -8,6 +8,10 @@
 #define KEYCODE_L 0x44
 #define KEYCODE_U 0x41
 #define KEYCODE_D 0x42
+#define KEYCODE_A 0x61
+#define KEYCODE_Z 0x7A
+#define KEYCODE_S 0x73
+#define KEYCODE_X 0x78
 #define KEYCODE_Q 0x71
 #define KEYCODE_SPACE 0x20
 
@@ -19,13 +23,18 @@ class TeleopRosAria
   private:
     ros::NodeHandle nh_;
     double linear_, angular_, l_scale_, a_scale_;
+    double current_linear_, current_angular_, step_linear_, step_angular_;
     ros::Publisher twist_pub_;
 };
 TeleopRosAria::TeleopRosAria():
   linear_(0),
   angular_(0),
   l_scale_(2.0),
-  a_scale_(2.0)
+  a_scale_(2.0),
+  current_angular_(0.1),
+  current_linear_(0.1),
+  step_linear_(0.2),
+  step_angular_(0.1)
 {
   nh_.param("scale_angular", a_scale_, a_scale_);
   nh_.param("scale_linear", l_scale_, l_scale_);
@@ -64,6 +73,8 @@ void TeleopRosAria::keyLoop()
   puts("Use arrow keys to move the robot.");
   puts("Press the space bar to stop the robot.");
   puts("Press q to stop the program");
+  puts("a/z - Increase/decrease linear velocity");
+  puts("s/x - Increase/decrease angular velocity");
   for(;;)
   {
     // get the next event from the keyboard
@@ -73,33 +84,66 @@ void TeleopRosAria::keyLoop()
   	  exit(-1);
 	  }
     linear_=angular_=0;
+    char printable[100];
     ROS_DEBUG("value: 0x%02X\n", c);
     switch(c)
 	  {
     	case KEYCODE_L:
     	  ROS_DEBUG("LEFT");
-    	  angular_ = 0.1;
+    	  angular_ = current_angular_;
     	  linear_ = 0;
     	  dirty = true;
     	  break;
     	case KEYCODE_R:
     	  ROS_DEBUG("RIGHT");
-    	  angular_ = -0.1;
+    	  angular_ = -current_angular_;
     	  linear_ = 0;
     	  dirty = true;
     	  break;
     	case KEYCODE_U:
     	  ROS_DEBUG("UP");
-    	  linear_ = 0.1;
+    	  linear_ = current_linear_;
     	  angular_ = 0;
     	  dirty = true;
     	  break;
     	case KEYCODE_D:
     	  ROS_DEBUG("DOWN");
-    	  linear_ = -0.1;
+    	  linear_ = -current_linear_;
     	  angular_ = 0;
     	  dirty = true;
     	  break;
+	case KEYCODE_A:
+	  ROS_DEBUG("INCREASE LINEAR SPEED");
+	  current_linear_ += step_linear_;
+	  sprintf(printable, "Linear speed: %02f", current_linear_);
+	  puts(printable);
+	  dirty=true;
+	  break;
+	case KEYCODE_Z:
+	  ROS_DEBUG("DECREASE LINEAR SPEED");
+          current_linear_ -= step_linear_;
+	  if(current_linear_ < 0)
+	      current_linear_ = 0;
+          sprintf(printable, "Linear speed: %02f", current_linear_);
+          puts(printable);
+          dirty=true;
+          break;
+	case KEYCODE_S:
+	  ROS_DEBUG("INCREASE ANGULAR SPEED");
+          current_angular_ += step_angular_;
+          sprintf(printable, "Angular speed: %02f", current_angular_);
+          puts(printable);
+          dirty=true;
+          break;
+	case KEYCODE_X:
+	  ROS_DEBUG("DECREASE LINEAR SPEED");
+          current_angular_ -= step_angular_;
+	  if(current_angular_ < 0)
+	      current_angular_ = 0;
+          sprintf(printable, "Angular speed: %02f", current_angular_);
+          puts(printable);
+          dirty=true;
+          break;
     	case KEYCODE_SPACE:
     	  ROS_DEBUG("STOP");
     	  linear_ = 0;


### PR DESCRIPTION
Hello! I'm a mobile robots developer from Brazil, currently using your package to operate a Pioneer P3AT.
As I have been working with this robot for quite some time now, I thought of a feature for your package that could be interesting.

I added four new key codes to teleop.cpp, corresponding to the A, Z, S and X keys.
They are used to increase and decrease linear and angular velocities in execution time, eliminating the need to change the velocities in the teleop code and recompile.
New variables (current_linear_, current_angular_, step_linear_ and step_angular_) and cases in the switch were created to accomodate this change. The current velocities are displayed every time the user changes them.

I hope you like it! Please feel free to contact me if you have any questions.

Regards,
Renan